### PR TITLE
v1.3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Net7_updates*.*
 *.pdf
 /vintagestory-at-chain.pem
 PyInstaller/
+metadata.yml
 
 
 # Byte-compiled / optimized / DLL files

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 v1.3.3
 - fixed: crash when mods do not have a modid key in the modinfo.json.
 - added: a crash-log.txt file is generated when a common crash occurs.
+- fixed: in some rare cases mods don't update if you set a limit for the game version.
 
 v1.3.2
 - fixed: another crash with some rare mods due to update to 1.3.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+v1.3.3
+- fixed: crash when mods do not have a modid key in the modinfo.json.
+- added: a crash-log.txt file is generated when a common crash occurs.
+
 v1.3.2
 - fixed: another crash with some rare mods due to update to 1.3.0
 


### PR DESCRIPTION
- fixed: crash when mods do not have a modid key in the modinfo.json.
- added: a crash-log.txt file is generated when a common crash occurs.
- fixed: in some rare cases mods don't update if you set a limit for the game version.
