### PR TITLE
Warn when the Mods path is wrong

### DIFF
--- a/VS_ModsUpdater.py
+++ b/VS_ModsUpdater.py
@@ -144,6 +144,7 @@ class LanguageChoice:
             self.ErrorCreationPDF = desc['ErrorCreationPDF']
             self.end_of_prg = desc['end_of_prg']
             self.error_msg = desc['error_msg']
+            self.mod_path_failure = desc['mod_path_failure']
 
         # On crée une liste pour les réponses O/N
         self.list_yesno = [self.yes.lower(), self.no.lower(), self.yes[0].lower(),
@@ -1145,6 +1146,8 @@ if path_mods.is_dir():
     inst.mods_list()
     inst.update_mods()
     inst.resume()
+else:
+    print(f'[red]{LanguageChoice().mod_path_failure}[/red] ({path_mods})\n')
 
 # Création du pdf (si argument nopause est false)
 if args.nopause == 'false' or args.makepdf == 'true':

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -42,5 +42,6 @@
 	"pdfTitle" : "Installed mods",
 	"ErrorCreationPDF" : "Unable to create file. Check that it is not already open.",
 	"end_of_prg" : "ModsUpdater will now shut down.",
-	"error_msg" : "An error has occurred. Please consult the debug file."
+	"error_msg" : "An error has occurred. Please consult the debug file.",
+	"mod_path_failure": "Mods path does not exist or is not a directory"
 }

--- a/lang/fr_FR.json
+++ b/lang/fr_FR.json
@@ -42,5 +42,6 @@
 	"pdfTitle" : "Liste des mods installés",
 	"ErrorCreationPDF" : "Impossible de créer le fichier. Vérifiez qu'il n'est pas déjà ouvert.",
 	"end_of_prg" : "ModsUpdater va maintenant se fermer.",
-	"error_msg" : "Une erreur s'est produite. Veuillez consulter le fichier de débogage."
+	"error_msg" : "Une erreur s'est produite. Veuillez consulter le fichier de débogage.",
+	"mod_path_failure": "Le chemin poru le mods n'existe pas ou n'est pas un répertoire"
 }


### PR DESCRIPTION
And display the computer path in order to make debugging easier.

Note: I only translated in languages I speak properly
Note: the translation system is not really pleasant to use. There's no way to include variables, manage plurals etc etc. And having to declare all strings in LanguageChoice() is really not practical. I understand translation tools like gettext can be daunting but that would makes things easier for contributors and also for you in the end.